### PR TITLE
Use Watcher where new thread and watch loops are being created.

### DIFF
--- a/src/main/java/application/rest/v1/ApplicationCache.java
+++ b/src/main/java/application/rest/v1/ApplicationCache.java
@@ -16,6 +16,7 @@
 
 package application.rest.v1;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonObject;
 import com.ibm.kappnav.logging.Logger;
 import com.squareup.okhttp.Call;
@@ -30,6 +32,7 @@ import com.squareup.okhttp.Call;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CustomObjectsApi;
+import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watch.Response;
 
 /**
@@ -95,6 +98,12 @@ public class ApplicationCache {
                 final CustomObjectsApi coa = new CustomObjectsApi();
                 coa.setApiClient(client);
                 return coa.listClusterCustomObjectCall(APP_GROUP, APP_VERSION, APP_PLURAL, null, null, null, Boolean.TRUE, null, null);
+            }
+            
+            @SuppressWarnings("serial")
+            @Override
+            public Type getWatchType() {
+                return new TypeToken<Watch.Response<Object>>() {}.getType();
             }
 
             @Override

--- a/src/main/java/application/rest/v1/CustomResourceWatcher.java
+++ b/src/main/java/application/rest/v1/CustomResourceWatcher.java
@@ -24,7 +24,6 @@ import com.squareup.okhttp.Call;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CustomObjectsApi;
-import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.util.Watch.Response;
 
 /**

--- a/src/main/java/application/rest/v1/CustomResourceWatcher.java
+++ b/src/main/java/application/rest/v1/CustomResourceWatcher.java
@@ -16,6 +16,9 @@
 
 package application.rest.v1;
 
+import java.lang.reflect.Type;
+
+import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ibm.kappnav.logging.Logger;
@@ -24,6 +27,7 @@ import com.squareup.okhttp.Call;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CustomObjectsApi;
+import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watch.Response;
 
 /**
@@ -54,6 +58,12 @@ public class CustomResourceWatcher {
                 CustomObjectsApi coa = new CustomObjectsApi();
                 coa.setApiClient(client);
                 return coa.listNamespacedCustomObjectCall(KAPPNAV_CR_GROUP, KAPPNAV_CR_VERSION, KAPPNAV_NAMESPACE, KAPPNAV_CR_PLURAL, null, null, null, Boolean.TRUE, null, null);
+            }
+            
+            @SuppressWarnings("serial")
+            @Override
+            public Type getWatchType() {
+                return new TypeToken<Watch.Response<Object>>() {}.getType();
             }
 
             @Override

--- a/src/main/java/application/rest/v1/CustomResourceWatcher.java
+++ b/src/main/java/application/rest/v1/CustomResourceWatcher.java
@@ -43,7 +43,7 @@ public class CustomResourceWatcher {
     private static final String WATCHER_THREAD_NAME = "kAppNav Custom Resource Watcher";
 
     public static void startCustomResourceWatcher() {
-        Watcher.start(new Watcher.Handler<V1ConfigMap>() {
+        Watcher.start(new Watcher.Handler<Object>() {
 
             @Override
             public String getWatcherThreadName() {
@@ -58,7 +58,7 @@ public class CustomResourceWatcher {
             }
 
             @Override
-            public void processResponse(ApiClient client, Response<V1ConfigMap> response) {
+            public void processResponse(ApiClient client, Response<Object> response) {
                 JsonObject o = KAppNavEndpoint.getItemAsObject(client, response.object);                               
                 if (o != null) {
                     // Only handle ADDED and MODIFIED cases

--- a/src/main/java/application/rest/v1/Watcher.java
+++ b/src/main/java/application/rest/v1/Watcher.java
@@ -73,7 +73,7 @@ public class Watcher {
                                 Logger.log(getClass().getName(), "run", Logger.LogType.DEBUG, "Watch started for " + h.getClass().getName() + ".");
                             }
 
-                            // Note: While the watch is active this iterator loop will block waiting for notifications of ConfigMap changes from the Kube API. 
+                            // Note: While the watch is active this iterator loop will block waiting for notifications of resource changes from the Kube API. 
                             for (Watch.Response<T> item : watch) {
                                 h.processResponse(client, item);
                             }
@@ -99,7 +99,7 @@ public class Watcher {
                         }
                     }
                     if (!autoRestart) {
-                        // Sleep until a request is made for a ConfigMap, then try to re-establish the watch.
+                        // Sleep until notified by another thread, then try to re-establish the watch.
                         synchronized (LOCK) {
                             try {
                                 LOCK.wait();

--- a/src/main/java/application/rest/v1/Watcher.java
+++ b/src/main/java/application/rest/v1/Watcher.java
@@ -16,9 +16,9 @@
 
 package application.rest.v1;
 
+import java.lang.reflect.Type;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.reflect.TypeToken;
 import com.ibm.kappnav.logging.Logger;
 import com.squareup.okhttp.Call;
 import com.squareup.okhttp.OkHttpClient;
@@ -35,6 +35,7 @@ public class Watcher {
     public interface Handler<T> {
         public String getWatcherThreadName();
         public Call createWatchCall(ApiClient client) throws ApiException;
+        public Type getWatchType();
         public void processResponse(ApiClient client, Watch.Response<T> response);
         public void shutdown(ApiClient client);
     }
@@ -50,7 +51,6 @@ public class Watcher {
         // Synchronization lock used for waking up the watcher thread.
         final Object LOCK = new Object();
         Thread t = new Thread(new Runnable() {
-            @SuppressWarnings("serial")
             @Override
             public void run() {
                 while (true) {
@@ -67,7 +67,7 @@ public class Watcher {
                             watch = Watch.createWatch(
                                     client,
                                     h.createWatchCall(client),
-                                    new TypeToken<Watch.Response<T>>() {}.getType());
+                                    h.getWatchType());
                             
                             if (Logger.isDebugEnabled()) {
                                 Logger.log(getClass().getName(), "run", Logger.LogType.DEBUG, "Watch started for " + h.getClass().getName() + ".");

--- a/src/main/java/application/rest/v1/configmaps/ConfigMapCache.java
+++ b/src/main/java/application/rest/v1/configmaps/ConfigMapCache.java
@@ -17,12 +17,14 @@
 package application.rest.v1.configmaps;
 
 import java.lang.ref.SoftReference;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.xml.namespace.QName;
 
+import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonElement;
 import com.ibm.kappnav.logging.Logger;
 import com.squareup.okhttp.Call;
@@ -35,6 +37,7 @@ import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watch.Response;
 
 /**
@@ -77,6 +80,12 @@ public class ConfigMapCache {
                 Selector selector = new Selector();
                 selector.addMatchLabel("app.kubernetes.io/managed-by", "kappnav-operator");
                 return api.listNamespacedConfigMapCall(KAPPNAV_NAMESPACE, null, null, null, null, selector.toString(), null, null, null, Boolean.TRUE, null, null);
+            }
+            
+            @SuppressWarnings("serial")
+            @Override
+            public Type getWatchType() {
+                return new TypeToken<Watch.Response<V1ConfigMap>>() {}.getType();
             }
 
             @Override


### PR DESCRIPTION
ConfigMapCache and CustomResourceWatcher have copies of the logic in Watcher. Refactor to use the Watcher and reduce code duplication.