### PR TITLE
feat(openapi): development tool to expose openapi

### DIFF
--- a/tools/openapi/README.md
+++ b/tools/openapi/README.md
@@ -1,0 +1,1 @@
+Script will create a Service and Route to expose the openapi UI to developers

--- a/tools/openapi/exposeOpenApi.sh
+++ b/tools/openapi/exposeOpenApi.sh
@@ -1,0 +1,2 @@
+kubectl create -f service.yaml -n kappnav
+kubectl create -f route.yaml -n kappnav

--- a/tools/openapi/route.yaml
+++ b/tools/openapi/route.yaml
@@ -1,0 +1,10 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: openapi
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: kappnav-api-service

--- a/tools/openapi/service.yaml
+++ b/tools/openapi/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kappnav-api-service
+spec:
+  type: NodePort
+  ports:
+  - port: 9080
+    targetPort: 9080
+    protocol: TCP
+    name: http
+  selector:
+    app.kubernetes.io/component: kappnav-ui


### PR DESCRIPTION
The `exposeOpenApi.sh` is a "one button push" to expose the `9080` port on the Liberty server running the API code.  The script makes it easy to expose the OpenAPI UI for developers who want to invoke API calls directly from their machines instead of proxying through the NodeJS server (aka UI container)

### Minor Limitation
I tried adding `path: /openapi/ui/` to the `route.yaml`, but the route would break.  So the script isn't truely a "one button push", but it's close.