### PR TITLE
feat: Improve the exposeOpenApi.sh

### DIFF
--- a/tools/openapi/exposeOpenApi.sh
+++ b/tools/openapi/exposeOpenApi.sh
@@ -1,2 +1,33 @@
-kubectl create -f service.yaml -n kappnav
-kubectl create -f route.yaml -n kappnav
+#!/bin/bash
+
+if [ -z "$1" ] && [ "$1" = "-h" ] || [ "$1" = "help" ] || [ "$1" = "-?" ]; then
+    echo "Exposes the OpenAPI Console by creating a Service and Route for the API server"
+    echo ""
+    echo "syntax:"
+    echo "exposeOpenApi.sh [-n namespace]"
+    echo ""
+    echo "-n namespaces"
+    echo "     Optional.  The namespace where the OpenAPI container is running.  Default value is kappnav."
+    exit 0
+fi
+
+NAMESPACE="kappnav"
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -n)
+    NAMESPACE="$2"
+    shift # past argument
+    shift # past value
+    ;;
+esac
+done
+
+echo "Targeting namespace: $NAMESPACE"
+
+scriptPath=`dirname "$0"`
+kubectl create -f $scriptPath/service.yaml -n $NAMESPACE
+kubectl create -f $scriptPath/route.yaml -n $NAMESPACE


### PR DESCRIPTION
Follow up to #57

- Add the ability to run the exposeOpenApi.sh script from outside the
directory that holds the script.  For example, now you can run the
script from the build folder, which you often do after running
install.sh.

Command line example of running the script from the build folder:
`~/kappnav/build# ../apis/tools/openapi/exposeOpenApi.sh`

- Add the optional flag `-n` for providing a target namespace.  Default
is kappnav namespace.

Example of running the script with the optional namespace flag:
`exposeOpenApi.sh -n kinueng`