### PR TITLE
feat: Add Open Liberty development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ backend API server
 
 # build
 Build this component by running it's build.sh script in the project root directory.
+
+# development
+Run the API server in development mode [1] with command `mvn liberty:dev`
+
+[1] https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Plugin to run Open Liberty in dev mode -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <bootstrapProperties>
+                        <app.location>${project.artifactId}-${project.version}.war</app.location>
+                        <default.http.port>${testServerHttpPort}</default.http.port>
+                        <default.https.port>${testServerHttpsPort}</default.https.port>
+                    </bootstrapProperties>
+                </configuration>
+            </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>


### PR DESCRIPTION
Open Liberty dev mode allows for developers to run the API server, make changes to the Java code, and have those changes get automatically pushed into the running API server.

I double checked with a developer on the OpenLiberty devMode team.  He mentioned that having `io.openliberty.tools` plugin in our Maven `pom.xml` will not create any devMode specific files unless devMode is used.  My concern is to avoid having devMode files in the final `war` file.  Since the build process avoids using devMode, there should be no regression on the types of files included in the `war` file.