### PR TITLE
apiVersion: Add support for the percentage symbol

### DIFF
--- a/src/main/java/application/rest/v1/KAppNavEndpoint.java
+++ b/src/main/java/application/rest/v1/KAppNavEndpoint.java
@@ -53,7 +53,7 @@ public abstract class KAppNavEndpoint {
 
     protected static final String NAME_PATTERN_ONE_OR_MORE = "^[a-z0-9-.:]+$";
     protected static final String NAME_PATTERN_ZERO_OR_MORE = "^[a-z0-9-.:]*$";
-    protected static final String API_VERSION_PATTERN_ZERO_OR_MORE = "^[a-z0-9-.:/]*$";
+    protected static final String API_VERSION_PATTERN_ZERO_OR_MORE = "^[a-z0-9-.:/%]*$";
     
     private static final boolean DISABLE_TRUST_ALL_CERTS;
     private static final String DISABLE_TRUST_ALL_CERTS_PROPERTY = "kappnav.disable.trust.all.certs";


### PR DESCRIPTION
- The apiVersion value will be url encoded, which means the `%` can
exist.  Add the `%` to the regular expression for the apiVersion
query parameter.

# Example of why we need `%`
When passing an `apiVersion` of `apps/v1`, the API call will have a query parameter of `apiVersion=apps%2Fv1`.  The `@QueryParam("apiVersion")`  Java annotation will decode the value back to `apps/v1`